### PR TITLE
Add Otter.ai MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A comprehensive collection of Model Context Protocol (MCP) servers designed for 
 - **OpenAI** - Full AI capabilities including chat, image generation, audio processing, and more
 - **Perplexity** - Real-time web search and research with citations and fact-checking
 - **Puppeteer** - Web scraping and automation for data extraction and testing
+- **Otter.ai** - Transcription management with audio upload and transcript retrieval
 
 ## Quick Start
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,346 +1,346 @@
 #!/usr/bin/env node
-
-// src/index.ts
-import { Server } from "@modelcontextprotocol/sdk/server/index.js";
-import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import {
-  CallToolRequestSchema,
-  ListToolsRequestSchema
-} from "@modelcontextprotocol/sdk/types.js";
-import express from "express";
-import cors from "cors";
-import dotenv from "dotenv";
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { CallToolRequestSchema, ListToolsRequestSchema, } from '@modelcontextprotocol/sdk/types.js';
+import express from 'express';
+import cors from 'cors';
+import dotenv from 'dotenv';
+// Load environment variables
 dotenv.config();
+// Helper function to check for secrets
 function checkSecrets() {
-  return {
-    GOOGLE_CLIENT_ID: process.env.GOOGLE_CLIENT_ID,
-    GOOGLE_CLIENT_SECRET: process.env.GOOGLE_CLIENT_SECRET,
-    GOOGLE_REFRESH_TOKEN: process.env.GOOGLE_REFRESH_TOKEN,
-    DROPBOX_ACCESS_TOKEN: process.env.DROPBOX_ACCESS_TOKEN,
-    NOTION_INTEGRATION_SECRET: process.env.NOTION_INTEGRATION_SECRET,
-    OPENAI_API_KEY: process.env.OPENAI_API_KEY,
-    PERPLEXITY_API_KEY: process.env.PERPLEXITY_API_KEY
-  };
+    return {
+        GOOGLE_CLIENT_ID: process.env.GOOGLE_CLIENT_ID,
+        GOOGLE_CLIENT_SECRET: process.env.GOOGLE_CLIENT_SECRET,
+        GOOGLE_REFRESH_TOKEN: process.env.GOOGLE_REFRESH_TOKEN,
+        DROPBOX_ACCESS_TOKEN: process.env.DROPBOX_ACCESS_TOKEN,
+        NOTION_INTEGRATION_SECRET: process.env.NOTION_INTEGRATION_SECRET,
+        OPENAI_API_KEY: process.env.OPENAI_API_KEY,
+        PERPLEXITY_API_KEY: process.env.PERPLEXITY_API_KEY,
+        OTTER_API_TOKEN: process.env.OTTER_API_TOKEN,
+    };
 }
-var MainMCPServer = class {
-  constructor() {
-    this.availableServers = [];
-    this.server = new Server(
-      {
-        name: "iphone-mcp-servers",
-        version: "1.0.0",
-        description: "Main MCP server hub for iPhone integration with Gmail, Google Drive, Google Calendar, Dropbox, Notion, OpenAI, Perplexity, and Puppeteer"
-      },
-      {
-        capabilities: {
-          tools: {}
+class MainMCPServer {
+    constructor() {
+        this.availableServers = [];
+        this.server = new Server({
+            name: 'iphone-mcp-servers',
+            version: '1.0.0',
+            description: 'Main MCP server hub for iPhone integration with Gmail, Google Drive, Google Calendar, Dropbox, Notion, OpenAI, Perplexity, and Puppeteer'
+        }, {
+            capabilities: {
+                tools: {},
+            },
+        });
+        this.checkAvailableServers();
+        this.setupHandlers();
+    }
+    checkAvailableServers() {
+        const secrets = checkSecrets();
+        if (secrets.GOOGLE_CLIENT_ID && secrets.GOOGLE_CLIENT_SECRET && secrets.GOOGLE_REFRESH_TOKEN) {
+            this.availableServers.push('Gmail', 'Google Drive', 'Google Calendar');
         }
-      }
-    );
-    this.checkAvailableServers();
-    this.setupHandlers();
-  }
-  checkAvailableServers() {
-    const secrets = checkSecrets();
-    if (secrets.GOOGLE_CLIENT_ID && secrets.GOOGLE_CLIENT_SECRET && secrets.GOOGLE_REFRESH_TOKEN) {
-      this.availableServers.push("Gmail", "Google Drive", "Google Calendar");
-    }
-    if (secrets.DROPBOX_ACCESS_TOKEN) {
-      this.availableServers.push("Dropbox");
-    }
-    if (secrets.NOTION_INTEGRATION_SECRET) {
-      this.availableServers.push("Notion");
-    }
-    if (secrets.OPENAI_API_KEY) {
-      this.availableServers.push("OpenAI");
-    }
-    if (secrets.PERPLEXITY_API_KEY) {
-      this.availableServers.push("Perplexity");
-    }
-    this.availableServers.push("Puppeteer");
-  }
-  setupHandlers() {
-    this.server.setRequestHandler(ListToolsRequestSchema, async () => {
-      return {
-        tools: this.getTools()
-      };
-    });
-    this.server.setRequestHandler(CallToolRequestSchema, async (request) => {
-      const { name, arguments: args } = request.params;
-      try {
-        switch (name) {
-          case "list_available_servers":
-            return await this.listAvailableServers();
-          case "get_server_info":
-            return await this.getServerInfo(args);
-          case "check_requirements":
-            return await this.checkRequirements();
-          case "get_setup_instructions":
-            return await this.getSetupInstructions(args);
-          default:
-            throw new Error(`Unknown tool: ${name}`);
+        if (secrets.DROPBOX_ACCESS_TOKEN) {
+            this.availableServers.push('Dropbox');
         }
-      } catch (error) {
-        return {
-          content: [
+        if (secrets.NOTION_INTEGRATION_SECRET) {
+            this.availableServers.push('Notion');
+        }
+        if (secrets.OPENAI_API_KEY) {
+            this.availableServers.push('OpenAI');
+        }
+        if (secrets.PERPLEXITY_API_KEY) {
+            this.availableServers.push('Perplexity');
+        }
+        if (secrets.OTTER_API_TOKEN) {
+            this.availableServers.push('Otter.ai');
+        }
+        // Puppeteer is always available (no API key needed)
+        this.availableServers.push('Puppeteer');
+    }
+    setupHandlers() {
+        this.server.setRequestHandler(ListToolsRequestSchema, async () => {
+            return {
+                tools: this.getTools(),
+            };
+        });
+        this.server.setRequestHandler(CallToolRequestSchema, async (request) => {
+            const { name, arguments: args } = request.params;
+            try {
+                switch (name) {
+                    case 'list_available_servers':
+                        return await this.listAvailableServers();
+                    case 'get_server_info':
+                        return await this.getServerInfo(args);
+                    case 'check_requirements':
+                        return await this.checkRequirements();
+                    case 'get_setup_instructions':
+                        return await this.getSetupInstructions(args);
+                    default:
+                        throw new Error(`Unknown tool: ${name}`);
+                }
+            }
+            catch (error) {
+                return {
+                    content: [
+                        {
+                            type: 'text',
+                            text: `Error: ${error instanceof Error ? error.message : 'Unknown error'}`,
+                        },
+                    ],
+                };
+            }
+        });
+    }
+    getTools() {
+        return [
             {
-              type: "text",
-              text: `Error: ${error instanceof Error ? error.message : "Unknown error"}`
-            }
-          ]
-        };
-      }
-    });
-  }
-  getTools() {
-    return [
-      {
-        name: "list_available_servers",
-        description: "List all available MCP servers based on configured credentials",
-        inputSchema: {
-          type: "object",
-          properties: {}
-        }
-      },
-      {
-        name: "get_server_info",
-        description: "Get detailed information about a specific MCP server",
-        inputSchema: {
-          type: "object",
-          properties: {
-            server: {
-              type: "string",
-              enum: ["Gmail", "Google Drive", "Google Calendar", "Dropbox", "Notion", "OpenAI", "Perplexity", "Puppeteer"],
-              description: "Server name to get information about"
-            }
-          },
-          required: ["server"]
-        }
-      },
-      {
-        name: "check_requirements",
-        description: "Check system requirements and missing credentials",
-        inputSchema: {
-          type: "object",
-          properties: {}
-        }
-      },
-      {
-        name: "get_setup_instructions",
-        description: "Get setup instructions for a specific service",
-        inputSchema: {
-          type: "object",
-          properties: {
-            service: {
-              type: "string",
-              enum: ["Gmail", "Google Drive", "Google Calendar", "Dropbox", "Notion", "OpenAI", "Perplexity", "Puppeteer"],
-              description: "Service to get setup instructions for"
-            }
-          },
-          required: ["service"]
-        }
-      }
-    ];
-  }
-  async listAvailableServers() {
-    const serverInfo = this.availableServers.map((server2) => ({
-      name: server2,
-      status: "Available",
-      runCommand: `npm run ${server2.toLowerCase().replace(" ", "-")}`
-    }));
-    return {
-      content: [
-        {
-          type: "text",
-          text: JSON.stringify({
-            availableServers: serverInfo,
-            totalServers: this.availableServers.length,
-            note: "Run individual servers using the specified commands"
-          }, null, 2)
-        }
-      ]
-    };
-  }
-  async getServerInfo(args) {
-    const { server: server2 } = args;
-    const serverInfoMap = {
-      "Gmail": {
-        name: "Gmail MCP Server",
-        description: "Comprehensive Gmail integration for iPhone",
-        capabilities: [
-          "Search emails with advanced filters",
-          "Get email details and attachments",
-          "Send emails with CC/BCC support",
-          "Mark emails as read/unread",
-          "Delete emails",
-          "Get Gmail labels",
-          "Thread management"
-        ],
-        requiredSecrets: ["GOOGLE_CLIENT_ID", "GOOGLE_CLIENT_SECRET", "GOOGLE_REFRESH_TOKEN"],
-        runCommand: "npm run gmail"
-      },
-      "Google Drive": {
-        name: "Google Drive MCP Server",
-        description: "Full Google Drive integration for iPhone",
-        capabilities: [
-          "List and search files",
-          "Upload and download files",
-          "Create and manage folders",
-          "Share files with permissions",
-          "Move and copy files",
-          "Get file metadata"
-        ],
-        requiredSecrets: ["GOOGLE_CLIENT_ID", "GOOGLE_CLIENT_SECRET", "GOOGLE_REFRESH_TOKEN"],
-        runCommand: "npm run drive"
-      },
-      "Google Calendar": {
-        name: "Google Calendar MCP Server",
-        description: "Complete Google Calendar integration for iPhone",
-        capabilities: [
-          "List and search events",
-          "Create and update events",
-          "Manage attendees",
-          "Set reminders and recurring events",
-          "Get busy/free time information",
-          "Quick add events with natural language"
-        ],
-        requiredSecrets: ["GOOGLE_CLIENT_ID", "GOOGLE_CLIENT_SECRET", "GOOGLE_REFRESH_TOKEN"],
-        runCommand: "npm run calendar"
-      },
-      "Dropbox": {
-        name: "Dropbox MCP Server",
-        description: "Full Dropbox integration for iPhone",
-        capabilities: [
-          "Upload and download files",
-          "Create and manage folders",
-          "Search files and folders",
-          "Share files with links",
-          "Move and copy files",
-          "Get space usage information"
-        ],
-        requiredSecrets: ["DROPBOX_ACCESS_TOKEN"],
-        runCommand: "npm run dropbox"
-      },
-      "Notion": {
-        name: "Notion MCP Server",
-        description: "Complete Notion workspace integration for iPhone",
-        capabilities: [
-          "Search pages and databases",
-          "Create and update pages",
-          "Manage database entries",
-          "Work with blocks and content",
-          "User and workspace management",
-          "Advanced filtering and sorting"
-        ],
-        requiredSecrets: ["NOTION_INTEGRATION_SECRET"],
-        runCommand: "npm run notion"
-      },
-      "OpenAI": {
-        name: "OpenAI MCP Server",
-        description: "Full OpenAI API integration for iPhone",
-        capabilities: [
-          "Chat completions with GPT-4o",
-          "Image generation with DALL-E",
-          "Image editing and variations",
-          "Audio transcription and translation",
-          "Text-to-speech conversion",
-          "Content moderation",
-          "Embeddings creation"
-        ],
-        requiredSecrets: ["OPENAI_API_KEY"],
-        runCommand: "npm run openai"
-      },
-      "Perplexity": {
-        name: "Perplexity MCP Server",
-        description: "Perplexity AI search and research integration for iPhone",
-        capabilities: [
-          "Real-time web search and answers",
-          "Fact-checking with citations",
-          "Research topic analysis",
-          "Topic comparisons",
-          "Latest news retrieval",
-          "Content summarization"
-        ],
-        requiredSecrets: ["PERPLEXITY_API_KEY"],
-        runCommand: "npm run perplexity"
-      },
-      "Puppeteer": {
-        name: "Puppeteer MCP Server",
-        description: "Web scraping and automation for iPhone",
-        capabilities: [
-          "Web page scraping",
-          "Screenshot capture",
-          "PDF generation",
-          "Form filling and clicking",
-          "Link and image extraction",
-          "JavaScript execution",
-          "Cookie management"
-        ],
-        requiredSecrets: [],
-        runCommand: "npm run puppeteer"
-      }
-    };
-    const info = serverInfoMap[server2];
-    if (!info) {
-      throw new Error(`Unknown server: ${server2}`);
+                name: 'list_available_servers',
+                description: 'List all available MCP servers based on configured credentials',
+                inputSchema: {
+                    type: 'object',
+                    properties: {},
+                },
+            },
+            {
+                name: 'get_server_info',
+                description: 'Get detailed information about a specific MCP server',
+                inputSchema: {
+                    type: 'object',
+                    properties: {
+                        server: {
+                            type: 'string',
+                            enum: ['Gmail', 'Google Drive', 'Google Calendar', 'Dropbox', 'Notion', 'OpenAI', 'Perplexity', 'Puppeteer'],
+                            description: 'Server name to get information about',
+                        },
+                    },
+                    required: ['server'],
+                },
+            },
+            {
+                name: 'check_requirements',
+                description: 'Check system requirements and missing credentials',
+                inputSchema: {
+                    type: 'object',
+                    properties: {},
+                },
+            },
+            {
+                name: 'get_setup_instructions',
+                description: 'Get setup instructions for a specific service',
+                inputSchema: {
+                    type: 'object',
+                    properties: {
+                        service: {
+                            type: 'string',
+                            enum: ['Gmail', 'Google Drive', 'Google Calendar', 'Dropbox', 'Notion', 'OpenAI', 'Perplexity', 'Puppeteer'],
+                            description: 'Service to get setup instructions for',
+                        },
+                    },
+                    required: ['service'],
+                },
+            },
+        ];
     }
-    return {
-      content: [
-        {
-          type: "text",
-          text: JSON.stringify(info, null, 2)
+    async listAvailableServers() {
+        const serverInfo = this.availableServers.map(server => ({
+            name: server,
+            status: 'Available',
+            runCommand: `npm run ${server.toLowerCase().replace(' ', '-')}`,
+        }));
+        return {
+            content: [
+                {
+                    type: 'text',
+                    text: JSON.stringify({
+                        availableServers: serverInfo,
+                        totalServers: this.availableServers.length,
+                        note: 'Run individual servers using the specified commands',
+                    }, null, 2),
+                },
+            ],
+        };
+    }
+    async getServerInfo(args) {
+        const { server } = args;
+        const serverInfoMap = {
+            'Gmail': {
+                name: 'Gmail MCP Server',
+                description: 'Comprehensive Gmail integration for iPhone',
+                capabilities: [
+                    'Search emails with advanced filters',
+                    'Get email details and attachments',
+                    'Send emails with CC/BCC support',
+                    'Mark emails as read/unread',
+                    'Delete emails',
+                    'Get Gmail labels',
+                    'Thread management',
+                ],
+                requiredSecrets: ['GOOGLE_CLIENT_ID', 'GOOGLE_CLIENT_SECRET', 'GOOGLE_REFRESH_TOKEN'],
+                runCommand: 'npm run gmail',
+            },
+            'Google Drive': {
+                name: 'Google Drive MCP Server',
+                description: 'Full Google Drive integration for iPhone',
+                capabilities: [
+                    'List and search files',
+                    'Upload and download files',
+                    'Create and manage folders',
+                    'Share files with permissions',
+                    'Move and copy files',
+                    'Get file metadata',
+                ],
+                requiredSecrets: ['GOOGLE_CLIENT_ID', 'GOOGLE_CLIENT_SECRET', 'GOOGLE_REFRESH_TOKEN'],
+                runCommand: 'npm run drive',
+            },
+            'Google Calendar': {
+                name: 'Google Calendar MCP Server',
+                description: 'Complete Google Calendar integration for iPhone',
+                capabilities: [
+                    'List and search events',
+                    'Create and update events',
+                    'Manage attendees',
+                    'Set reminders and recurring events',
+                    'Get busy/free time information',
+                    'Quick add events with natural language',
+                ],
+                requiredSecrets: ['GOOGLE_CLIENT_ID', 'GOOGLE_CLIENT_SECRET', 'GOOGLE_REFRESH_TOKEN'],
+                runCommand: 'npm run calendar',
+            },
+            'Dropbox': {
+                name: 'Dropbox MCP Server',
+                description: 'Full Dropbox integration for iPhone',
+                capabilities: [
+                    'Upload and download files',
+                    'Create and manage folders',
+                    'Search files and folders',
+                    'Share files with links',
+                    'Move and copy files',
+                    'Get space usage information',
+                ],
+                requiredSecrets: ['DROPBOX_ACCESS_TOKEN'],
+                runCommand: 'npm run dropbox',
+            },
+            'Notion': {
+                name: 'Notion MCP Server',
+                description: 'Complete Notion workspace integration for iPhone',
+                capabilities: [
+                    'Search pages and databases',
+                    'Create and update pages',
+                    'Manage database entries',
+                    'Work with blocks and content',
+                    'User and workspace management',
+                    'Advanced filtering and sorting',
+                ],
+                requiredSecrets: ['NOTION_INTEGRATION_SECRET'],
+                runCommand: 'npm run notion',
+            },
+            'OpenAI': {
+                name: 'OpenAI MCP Server',
+                description: 'Full OpenAI API integration for iPhone',
+                capabilities: [
+                    'Chat completions with GPT-4o',
+                    'Image generation with DALL-E',
+                    'Image editing and variations',
+                    'Audio transcription and translation',
+                    'Text-to-speech conversion',
+                    'Content moderation',
+                    'Embeddings creation',
+                ],
+                requiredSecrets: ['OPENAI_API_KEY'],
+                runCommand: 'npm run openai',
+            },
+            'Perplexity': {
+                name: 'Perplexity MCP Server',
+                description: 'Perplexity AI search and research integration for iPhone',
+                capabilities: [
+                    'Real-time web search and answers',
+                    'Fact-checking with citations',
+                    'Research topic analysis',
+                    'Topic comparisons',
+                    'Latest news retrieval',
+                    'Content summarization',
+                ],
+                requiredSecrets: ['PERPLEXITY_API_KEY'],
+                runCommand: 'npm run perplexity',
+            },
+            'Puppeteer': {
+                name: 'Puppeteer MCP Server',
+                description: 'Web scraping and automation for iPhone',
+                capabilities: [
+                    'Web page scraping',
+                    'Screenshot capture',
+                    'PDF generation',
+                    'Form filling and clicking',
+                    'Link and image extraction',
+                    'JavaScript execution',
+                    'Cookie management',
+                ],
+                requiredSecrets: [],
+                runCommand: 'npm run puppeteer',
+            },
+        };
+        const info = serverInfoMap[server];
+        if (!info) {
+            throw new Error(`Unknown server: ${server}`);
         }
-      ]
-    };
-  }
-  async checkRequirements() {
-    const secrets = checkSecrets();
-    const requirements = {
-      system: {
-        nodejs: "Required (18+)",
-        typescript: "Installed",
-        dependencies: "Installed"
-      },
-      services: {
-        "Google Services (Gmail, Drive, Calendar)": {
-          required: ["GOOGLE_CLIENT_ID", "GOOGLE_CLIENT_SECRET", "GOOGLE_REFRESH_TOKEN"],
-          status: secrets.GOOGLE_CLIENT_ID && secrets.GOOGLE_CLIENT_SECRET && secrets.GOOGLE_REFRESH_TOKEN ? "Configured" : "Missing"
-        },
-        "Dropbox": {
-          required: ["DROPBOX_ACCESS_TOKEN"],
-          status: secrets.DROPBOX_ACCESS_TOKEN ? "Configured" : "Missing"
-        },
-        "Notion": {
-          required: ["NOTION_INTEGRATION_SECRET"],
-          status: secrets.NOTION_INTEGRATION_SECRET ? "Configured" : "Missing"
-        },
-        "OpenAI": {
-          required: ["OPENAI_API_KEY"],
-          status: secrets.OPENAI_API_KEY ? "Configured" : "Missing"
-        },
-        "Perplexity": {
-          required: ["PERPLEXITY_API_KEY"],
-          status: secrets.PERPLEXITY_API_KEY ? "Configured" : "Missing"
-        },
-        "Puppeteer": {
-          required: [],
-          status: "Ready (No API key needed)"
-        }
-      }
-    };
-    return {
-      content: [
-        {
-          type: "text",
-          text: JSON.stringify(requirements, null, 2)
-        }
-      ]
-    };
-  }
-  async getSetupInstructions(args) {
-    const { service } = args;
-    const instructionsMap = {
-      "Gmail": `
+        return {
+            content: [
+                {
+                    type: 'text',
+                    text: JSON.stringify(info, null, 2),
+                },
+            ],
+        };
+    }
+    async checkRequirements() {
+        const secrets = checkSecrets();
+        const requirements = {
+            system: {
+                nodejs: 'Required (18+)',
+                typescript: 'Installed',
+                dependencies: 'Installed',
+            },
+            services: {
+                'Google Services (Gmail, Drive, Calendar)': {
+                    required: ['GOOGLE_CLIENT_ID', 'GOOGLE_CLIENT_SECRET', 'GOOGLE_REFRESH_TOKEN'],
+                    status: (secrets.GOOGLE_CLIENT_ID && secrets.GOOGLE_CLIENT_SECRET && secrets.GOOGLE_REFRESH_TOKEN) ? 'Configured' : 'Missing',
+                },
+                'Dropbox': {
+                    required: ['DROPBOX_ACCESS_TOKEN'],
+                    status: secrets.DROPBOX_ACCESS_TOKEN ? 'Configured' : 'Missing',
+                },
+                'Notion': {
+                    required: ['NOTION_INTEGRATION_SECRET'],
+                    status: secrets.NOTION_INTEGRATION_SECRET ? 'Configured' : 'Missing',
+                },
+                'OpenAI': {
+                    required: ['OPENAI_API_KEY'],
+                    status: secrets.OPENAI_API_KEY ? 'Configured' : 'Missing',
+                },
+                'Perplexity': {
+                    required: ['PERPLEXITY_API_KEY'],
+                    status: secrets.PERPLEXITY_API_KEY ? 'Configured' : 'Missing',
+                },
+                'Puppeteer': {
+                    required: [],
+                    status: 'Ready (No API key needed)',
+                },
+            },
+        };
+        return {
+            content: [
+                {
+                    type: 'text',
+                    text: JSON.stringify(requirements, null, 2),
+                },
+            ],
+        };
+    }
+    async getSetupInstructions(args) {
+        const { service } = args;
+        const instructionsMap = {
+            'Gmail': `
 ## Gmail Setup Instructions
 
 1. **Enable Gmail API**:
@@ -368,7 +368,7 @@ var MainMCPServer = class {
    npm run gmail
    \`\`\`
       `,
-      "Google Drive": `
+            'Google Drive': `
 ## Google Drive Setup Instructions
 
 1. **Enable Google Drive API**:
@@ -389,7 +389,7 @@ var MainMCPServer = class {
    npm run drive
    \`\`\`
       `,
-      "Google Calendar": `
+            'Google Calendar': `
 ## Google Calendar Setup Instructions
 
 1. **Enable Google Calendar API**:
@@ -410,7 +410,7 @@ var MainMCPServer = class {
    npm run calendar
    \`\`\`
       `,
-      "Dropbox": `
+            'Dropbox': `
 ## Dropbox Setup Instructions
 
 1. **Create a Dropbox App**:
@@ -429,7 +429,7 @@ var MainMCPServer = class {
    npm run dropbox
    \`\`\`
       `,
-      "Notion": `
+            'Notion': `
 ## Notion Setup Instructions
 
 1. **Create a Notion Integration**:
@@ -454,7 +454,7 @@ var MainMCPServer = class {
    npm run notion
    \`\`\`
       `,
-      "OpenAI": `
+            'OpenAI': `
 ## OpenAI Setup Instructions
 
 1. **Get OpenAI API Key**:
@@ -472,7 +472,7 @@ var MainMCPServer = class {
    npm run openai
    \`\`\`
       `,
-      "Perplexity": `
+            'Perplexity': `
 ## Perplexity Setup Instructions
 
 1. **Get Perplexity API Key**:
@@ -490,7 +490,7 @@ var MainMCPServer = class {
    npm run perplexity
    \`\`\`
       `,
-      "Puppeteer": `
+            'Puppeteer': `
 ## Puppeteer Setup Instructions
 
 1. **No API Key Required**:
@@ -503,143 +503,158 @@ var MainMCPServer = class {
    \`\`\`
 
 3. **Note**: Puppeteer will download Chrome automatically on first run
-      `
-    };
-    const instructions = instructionsMap[service];
-    if (!instructions) {
-      throw new Error(`Unknown service: ${service}`);
-    }
-    return {
-      content: [
-        {
-          type: "text",
-          text: instructions
+      `,
+        };
+        const instructions = instructionsMap[service];
+        if (!instructions) {
+            throw new Error(`Unknown service: ${service}`);
         }
-      ]
-    };
-  }
-  setupHttpServer() {
-    const app = express();
-    app.use(cors());
-    app.use(express.json());
-    app.get("/", (req, res) => {
-      const secrets = checkSecrets();
-      res.json({
-        name: "iPhone MCP Server Hub",
-        version: "1.0.0",
-        status: "running",
-        availableServers: this.availableServers,
-        configuration: {
-          googleServices: !!(secrets.GOOGLE_CLIENT_ID && secrets.GOOGLE_CLIENT_SECRET && secrets.GOOGLE_REFRESH_TOKEN),
-          dropbox: !!secrets.DROPBOX_ACCESS_TOKEN,
-          notion: !!secrets.NOTION_INTEGRATION_SECRET,
-          openai: !!secrets.OPENAI_API_KEY,
-          perplexity: !!secrets.PERPLEXITY_API_KEY,
-          puppeteer: true
-        },
-        endpoints: {
-          health: "/",
-          servers: "/api/servers",
-          serverInfo: "/api/servers/:name",
-          requirements: "/api/requirements",
-          setup: "/api/setup/:service"
+        return {
+            content: [
+                {
+                    type: 'text',
+                    text: instructions,
+                },
+            ],
+        };
+    }
+    setupHttpServer() {
+        const app = express();
+        app.use(cors());
+        app.use(express.json());
+        // Health check endpoint
+        app.get('/', (req, res) => {
+            const secrets = checkSecrets();
+            res.json({
+                name: 'iPhone MCP Server Hub',
+                version: '1.0.0',
+                status: 'running',
+                availableServers: this.availableServers,
+                configuration: {
+                    googleServices: !!(secrets.GOOGLE_CLIENT_ID && secrets.GOOGLE_CLIENT_SECRET && secrets.GOOGLE_REFRESH_TOKEN),
+                    dropbox: !!secrets.DROPBOX_ACCESS_TOKEN,
+                    notion: !!secrets.NOTION_INTEGRATION_SECRET,
+                    openai: !!secrets.OPENAI_API_KEY,
+                    perplexity: !!secrets.PERPLEXITY_API_KEY,
+                    puppeteer: true
+                },
+                endpoints: {
+                    health: '/',
+                    servers: '/api/servers',
+                    serverInfo: '/api/servers/:name',
+                    requirements: '/api/requirements',
+                    setup: '/api/setup/:service'
+                }
+            });
+        });
+        // List available servers
+        app.get('/api/servers', async (req, res) => {
+            try {
+                const result = await this.listAvailableServers();
+                res.json(JSON.parse(result.content[0].text));
+            }
+            catch (error) {
+                res.status(500).json({ error: error instanceof Error ? error.message : 'Unknown error' });
+            }
+        });
+        // Get server info
+        app.get('/api/servers/:name', async (req, res) => {
+            try {
+                const result = await this.getServerInfo({ server: req.params.name });
+                res.json(JSON.parse(result.content[0].text));
+            }
+            catch (error) {
+                res.status(400).json({ error: error instanceof Error ? error.message : 'Unknown error' });
+            }
+        });
+        // Check requirements
+        app.get('/api/requirements', async (req, res) => {
+            try {
+                const result = await this.checkRequirements();
+                res.json(JSON.parse(result.content[0].text));
+            }
+            catch (error) {
+                res.status(500).json({ error: error instanceof Error ? error.message : 'Unknown error' });
+            }
+        });
+        // Get setup instructions
+        app.get('/api/setup/:service', async (req, res) => {
+            try {
+                const result = await this.getSetupInstructions({ service: req.params.service });
+                res.json({ instructions: result.content[0].text });
+            }
+            catch (error) {
+                res.status(400).json({ error: error instanceof Error ? error.message : 'Unknown error' });
+            }
+        });
+        const PORT = Number(process.env.PORT) || 5000;
+        const HOST = process.env.HOST || '0.0.0.0';
+        const server = app.listen(PORT, HOST, () => {
+            console.log(`🌐 HTTP API server running on http://${HOST}:${PORT}`);
+            console.log(`📊 Health check: http://${HOST}:${PORT}/`);
+            console.log(`🔗 API docs: http://${HOST}:${PORT}/api/servers`);
+            console.log(`🚀 Server ready for deployment on port ${PORT}`);
+        });
+        // Handle graceful shutdown
+        process.on('SIGTERM', () => {
+            console.log('📴 Received SIGTERM, shutting down gracefully...');
+            server.close(() => {
+                console.log('🔴 Server closed');
+                process.exit(0);
+            });
+        });
+        process.on('SIGINT', () => {
+            console.log('📴 Received SIGINT, shutting down gracefully...');
+            server.close(() => {
+                console.log('🔴 Server closed');
+                process.exit(0);
+            });
+        });
+    }
+    async run() {
+        // Check if we're in development mode (when run directly)
+        if (process.argv.includes('--dev') || process.env.NODE_ENV === 'development') {
+            console.log('🚀 iPhone MCP Server Hub - Development Mode\n');
+            const secrets = checkSecrets();
+            console.log('📋 Available Servers:');
+            this.availableServers.forEach(server => {
+                console.log(`  ✅ ${server}`);
+            });
+            console.log('\n🔧 Configuration Status:');
+            console.log(`  Google Services: ${secrets.GOOGLE_CLIENT_ID ? '✅' : '❌'} Configured`);
+            console.log(`  Dropbox: ${secrets.DROPBOX_ACCESS_TOKEN ? '✅' : '❌'} Configured`);
+            console.log(`  Notion: ${secrets.NOTION_INTEGRATION_SECRET ? '✅' : '❌'} Configured`);
+            console.log(`  OpenAI: ${secrets.OPENAI_API_KEY ? '✅' : '❌'} Configured`);
+            console.log(`  Perplexity: ${secrets.PERPLEXITY_API_KEY ? '✅' : '❌'} Configured`);
+            console.log(`  Puppeteer: ✅ Ready (No API key needed)`);
+            console.log('\n🏃 Run individual servers:');
+            console.log('  npm run gmail      # Gmail MCP server');
+            console.log('  npm run drive      # Google Drive MCP server');
+            console.log('  npm run calendar   # Google Calendar MCP server');
+            console.log('  npm run dropbox    # Dropbox MCP server');
+            console.log('  npm run notion     # Notion MCP server');
+            console.log('  npm run openai     # OpenAI MCP server');
+            console.log('  npm run perplexity # Perplexity MCP server');
+            console.log('  npm run puppeteer  # Puppeteer MCP server');
+            console.log('\n💡 To connect an MCP client, run this server via stdio transport');
+            console.log('🌐 Starting HTTP API server for web access...\n');
+            // Start HTTP server in dev mode
+            this.setupHttpServer();
+            return;
         }
-      });
-    });
-    app.get("/api/servers", async (req, res) => {
-      try {
-        const result = await this.listAvailableServers();
-        res.json(JSON.parse(result.content[0].text));
-      } catch (error) {
-        res.status(500).json({ error: error instanceof Error ? error.message : "Unknown error" });
-      }
-    });
-    app.get("/api/servers/:name", async (req, res) => {
-      try {
-        const result = await this.getServerInfo({ server: req.params.name });
-        res.json(JSON.parse(result.content[0].text));
-      } catch (error) {
-        res.status(400).json({ error: error instanceof Error ? error.message : "Unknown error" });
-      }
-    });
-    app.get("/api/requirements", async (req, res) => {
-      try {
-        const result = await this.checkRequirements();
-        res.json(JSON.parse(result.content[0].text));
-      } catch (error) {
-        res.status(500).json({ error: error instanceof Error ? error.message : "Unknown error" });
-      }
-    });
-    app.get("/api/setup/:service", async (req, res) => {
-      try {
-        const result = await this.getSetupInstructions({ service: req.params.service });
-        res.json({ instructions: result.content[0].text });
-      } catch (error) {
-        res.status(400).json({ error: error instanceof Error ? error.message : "Unknown error" });
-      }
-    });
-    const PORT = Number(process.env.PORT) || 5e3;
-    const HOST = process.env.HOST || "0.0.0.0";
-    const server2 = app.listen(PORT, HOST, () => {
-      console.log(`\u{1F310} HTTP API server running on http://${HOST}:${PORT}`);
-      console.log(`\u{1F4CA} Health check: http://${HOST}:${PORT}/`);
-      console.log(`\u{1F517} API docs: http://${HOST}:${PORT}/api/servers`);
-      console.log(`\u{1F680} Server ready for deployment on port ${PORT}`);
-    });
-    process.on("SIGTERM", () => {
-      console.log("\u{1F4F4} Received SIGTERM, shutting down gracefully...");
-      server2.close(() => {
-        console.log("\u{1F534} Server closed");
-        process.exit(0);
-      });
-    });
-    process.on("SIGINT", () => {
-      console.log("\u{1F4F4} Received SIGINT, shutting down gracefully...");
-      server2.close(() => {
-        console.log("\u{1F534} Server closed");
-        process.exit(0);
-      });
-    });
-  }
-  async run() {
-    if (process.argv.includes("--dev") || process.env.NODE_ENV === "development") {
-      console.log("\u{1F680} iPhone MCP Server Hub - Development Mode\n");
-      const secrets = checkSecrets();
-      console.log("\u{1F4CB} Available Servers:");
-      this.availableServers.forEach((server2) => {
-        console.log(`  \u2705 ${server2}`);
-      });
-      console.log("\n\u{1F527} Configuration Status:");
-      console.log(`  Google Services: ${secrets.GOOGLE_CLIENT_ID ? "\u2705" : "\u274C"} Configured`);
-      console.log(`  Dropbox: ${secrets.DROPBOX_ACCESS_TOKEN ? "\u2705" : "\u274C"} Configured`);
-      console.log(`  Notion: ${secrets.NOTION_INTEGRATION_SECRET ? "\u2705" : "\u274C"} Configured`);
-      console.log(`  OpenAI: ${secrets.OPENAI_API_KEY ? "\u2705" : "\u274C"} Configured`);
-      console.log(`  Perplexity: ${secrets.PERPLEXITY_API_KEY ? "\u2705" : "\u274C"} Configured`);
-      console.log(`  Puppeteer: \u2705 Ready (No API key needed)`);
-      console.log("\n\u{1F3C3} Run individual servers:");
-      console.log("  npm run gmail      # Gmail MCP server");
-      console.log("  npm run drive      # Google Drive MCP server");
-      console.log("  npm run calendar   # Google Calendar MCP server");
-      console.log("  npm run dropbox    # Dropbox MCP server");
-      console.log("  npm run notion     # Notion MCP server");
-      console.log("  npm run openai     # OpenAI MCP server");
-      console.log("  npm run perplexity # Perplexity MCP server");
-      console.log("  npm run puppeteer  # Puppeteer MCP server");
-      console.log("\n\u{1F4A1} To connect an MCP client, run this server via stdio transport");
-      console.log("\u{1F310} Starting HTTP API server for web access...\n");
-      this.setupHttpServer();
-      return;
+        // Production mode - check if we should run HTTP server for deployment
+        if (process.env.NODE_ENV === 'production' || process.env.RUN_HTTP_SERVER === 'true') {
+            console.log('🌐 iPhone MCP Server Hub - Production Mode (HTTP Server)');
+            console.log('🚀 Starting HTTP API server for web deployment...\n');
+            // Start HTTP server in production mode
+            this.setupHttpServer();
+            return;
+        }
+        // Default MCP stdio transport for MCP clients
+        const transport = new StdioServerTransport();
+        await this.server.connect(transport);
+        console.error('Main MCP server hub running on stdio');
     }
-    if (process.env.NODE_ENV === "production" || process.env.RUN_HTTP_SERVER === "true") {
-      console.log("\u{1F310} iPhone MCP Server Hub - Production Mode (HTTP Server)");
-      console.log("\u{1F680} Starting HTTP API server for web deployment...\n");
-      this.setupHttpServer();
-      return;
-    }
-    const transport = new StdioServerTransport();
-    await this.server.connect(transport);
-    console.error("Main MCP server hub running on stdio");
-  }
-};
-var server = new MainMCPServer();
+}
+const server = new MainMCPServer();
 server.run().catch(console.error);

--- a/dist/servers/otter.js
+++ b/dist/servers/otter.js
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+import axios from 'axios';
+import FormData from 'form-data';
+import { getRequiredEnv } from '../utils/env.js';
+class OtterMCPServer {
+    constructor() {
+        this.baseUrl = 'https://api.otter.ai';
+        this.server = new Server({
+            name: 'otter-ai-mcp-server',
+            version: '1.0.0',
+            description: 'MCP server for Otter.ai integration on iPhone'
+        }, {
+            capabilities: {
+                tools: {}
+            }
+        });
+        this.setupAuth();
+        this.setupHandlers();
+    }
+    setupAuth() {
+        try {
+            this.apiToken = getRequiredEnv('OTTER_API_TOKEN');
+        }
+        catch (error) {
+            console.error('Otter.ai authentication setup failed:', error);
+            throw error;
+        }
+    }
+    setupHandlers() {
+        this.server.setRequestHandler(ListToolsRequestSchema, async () => {
+            return { tools: this.getTools() };
+        });
+        this.server.setRequestHandler(CallToolRequestSchema, async (request) => {
+            const { name, arguments: args } = request.params;
+            try {
+                switch (name) {
+                    case 'upload_audio':
+                        return await this.uploadAudio(args);
+                    case 'list_transcripts':
+                        return await this.listTranscripts();
+                    case 'get_transcript':
+                        return await this.getTranscript(args);
+                    default:
+                        throw new Error(`Unknown tool: ${name}`);
+                }
+            }
+            catch (error) {
+                return {
+                    content: [
+                        {
+                            type: 'text',
+                            text: `Error: ${error instanceof Error ? error.message : 'Unknown error'}`
+                        }
+                    ]
+                };
+            }
+        });
+    }
+    getAxios() {
+        return axios.create({
+            baseURL: this.baseUrl,
+            headers: { Authorization: `Bearer ${this.apiToken}` }
+        });
+    }
+    getTools() {
+        return [
+            {
+                name: 'upload_audio',
+                description: 'Upload an audio file for transcription',
+                inputSchema: {
+                    type: 'object',
+                    properties: {
+                        file: { type: 'string', description: 'Base64 encoded audio file' },
+                        filename: { type: 'string', description: 'Filename for the upload' }
+                    },
+                    required: ['file', 'filename']
+                }
+            },
+            {
+                name: 'list_transcripts',
+                description: 'List available transcripts',
+                inputSchema: { type: 'object', properties: {} }
+            },
+            {
+                name: 'get_transcript',
+                description: 'Retrieve a specific transcript',
+                inputSchema: {
+                    type: 'object',
+                    properties: {
+                        id: { type: 'string', description: 'Transcript ID' }
+                    },
+                    required: ['id']
+                }
+            }
+        ];
+    }
+    async uploadAudio(args) {
+        const buffer = Buffer.from(args.file, 'base64');
+        const form = new FormData();
+        form.append('file', buffer, args.filename);
+        const axiosInstance = this.getAxios();
+        const response = await axiosInstance.post('/v1/import', form, {
+            headers: form.getHeaders()
+        });
+        return { content: [{ type: 'text', text: JSON.stringify(response.data, null, 2) }] };
+    }
+    async listTranscripts() {
+        const axiosInstance = this.getAxios();
+        const response = await axiosInstance.get('/v1/transcripts');
+        return { content: [{ type: 'text', text: JSON.stringify(response.data, null, 2) }] };
+    }
+    async getTranscript(args) {
+        const axiosInstance = this.getAxios();
+        const response = await axiosInstance.get(`/v1/transcripts/${args.id}`);
+        return { content: [{ type: 'text', text: JSON.stringify(response.data, null, 2) }] };
+    }
+    async run() {
+        const transport = new StdioServerTransport();
+        await this.server.connect(transport);
+        console.error('Otter.ai MCP server running on stdio');
+    }
+}
+const server = new OtterMCPServer();
+server.run().catch(console.error);

--- a/dist/utils/env.js
+++ b/dist/utils/env.js
@@ -20,5 +20,6 @@ export function checkSecrets() {
         NOTION_INTEGRATION_SECRET: process.env.NOTION_INTEGRATION_SECRET,
         OPENAI_API_KEY: process.env.OPENAI_API_KEY,
         PERPLEXITY_API_KEY: process.env.PERPLEXITY_API_KEY,
+        OTTER_API_TOKEN: process.env.OTTER_API_TOKEN,
     };
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "drizzle-zod": "^0.8.2",
         "dropbox": "^10.34.0",
         "express": "^5.1.0",
+        "form-data": "^4.0.3",
         "googleapis": "^152.0.0",
         "lucide-react": "^0.525.0",
         "openai": "^5.9.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "notion": "ts-node --project tsconfig.node.json src/servers/notion.ts",
     "openai": "ts-node --project tsconfig.node.json src/servers/openai.ts",
     "perplexity": "ts-node --project tsconfig.node.json src/servers/perplexity.ts",
-    "puppeteer": "ts-node --project tsconfig.node.json src/servers/puppeteer.ts"
+    "puppeteer": "ts-node --project tsconfig.node.json src/servers/puppeteer.ts",
+    "otter": "ts-node --project tsconfig.node.json src/servers/otter.ts"
   },
   "keywords": [],
   "author": "",
@@ -46,6 +47,7 @@
     "drizzle-zod": "^0.8.2",
     "dropbox": "^10.34.0",
     "express": "^5.1.0",
+    "form-data": "^4.0.3",
     "googleapis": "^152.0.0",
     "lucide-react": "^0.525.0",
     "openai": "^5.9.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ function checkSecrets() {
     NOTION_INTEGRATION_SECRET: process.env.NOTION_INTEGRATION_SECRET,
     OPENAI_API_KEY: process.env.OPENAI_API_KEY,
     PERPLEXITY_API_KEY: process.env.PERPLEXITY_API_KEY,
+    OTTER_API_TOKEN: process.env.OTTER_API_TOKEN,
   };
 }
 class MainMCPServer {
@@ -68,6 +69,10 @@ class MainMCPServer {
 
     if (secrets.PERPLEXITY_API_KEY) {
       this.availableServers.push('Perplexity');
+    }
+
+    if (secrets.OTTER_API_TOKEN) {
+      this.availableServers.push('Otter.ai');
     }
 
     // Puppeteer is always available (no API key needed)
@@ -704,3 +709,4 @@ class MainMCPServer {
 
 const server = new MainMCPServer();
 server.run().catch(console.error);
+

--- a/src/servers/calendar.ts
+++ b/src/servers/calendar.ts
@@ -787,3 +787,4 @@ class GoogleCalendarMCPServer {
 
 const server = new GoogleCalendarMCPServer();
 server.run().catch(console.error);
+

--- a/src/servers/drive.ts
+++ b/src/servers/drive.ts
@@ -651,3 +651,4 @@ class GoogleDriveMCPServer {
 
 const server = new GoogleDriveMCPServer();
 server.run().catch(console.error);
+

--- a/src/servers/dropbox.ts
+++ b/src/servers/dropbox.ts
@@ -693,3 +693,4 @@ class DropboxMCPServer {
 
 const server = new DropboxMCPServer();
 server.run().catch(console.error);
+

--- a/src/servers/gmail.ts
+++ b/src/servers/gmail.ts
@@ -531,3 +531,4 @@ class GmailMCPServer {
 
 const server = new GmailMCPServer();
 server.run().catch(console.error);
+

--- a/src/servers/notion.ts
+++ b/src/servers/notion.ts
@@ -824,3 +824,4 @@ class NotionMCPServer {
 
 const server = new NotionMCPServer();
 server.run().catch(console.error);
+

--- a/src/servers/openai.ts
+++ b/src/servers/openai.ts
@@ -877,3 +877,4 @@ class OpenAIMCPServer {
 
 const server = new OpenAIMCPServer();
 server.run().catch(console.error);
+

--- a/src/servers/otter.ts
+++ b/src/servers/otter.ts
@@ -1,0 +1,148 @@
+#!/usr/bin/env node
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { CallToolRequestSchema, ListToolsRequestSchema, Tool } from '@modelcontextprotocol/sdk/types.js';
+import axios from 'axios';
+import FormData from 'form-data';
+import { getRequiredEnv } from '../utils/env.js';
+import { OtterTranscript } from '../types/index.js';
+
+class OtterMCPServer {
+  private server: Server;
+  private apiToken!: string;
+  private baseUrl = 'https://api.otter.ai';
+
+  constructor() {
+    this.server = new Server(
+      {
+        name: 'otter-ai-mcp-server',
+        version: '1.0.0',
+        description: 'MCP server for Otter.ai integration on iPhone'
+      },
+      {
+        capabilities: {
+          tools: {}
+        }
+      }
+    );
+
+    this.setupAuth();
+    this.setupHandlers();
+  }
+
+  private setupAuth() {
+    try {
+      this.apiToken = getRequiredEnv('OTTER_API_TOKEN');
+    } catch (error) {
+      console.error('Otter.ai authentication setup failed:', error);
+      throw error;
+    }
+  }
+
+  private setupHandlers() {
+    this.server.setRequestHandler(ListToolsRequestSchema, async () => {
+      return { tools: this.getTools() };
+    });
+
+    this.server.setRequestHandler(CallToolRequestSchema, async (request) => {
+      const { name, arguments: args } = request.params;
+
+      try {
+        switch (name) {
+          case 'upload_audio':
+            return await this.uploadAudio(args as any);
+          case 'list_transcripts':
+            return await this.listTranscripts();
+          case 'get_transcript':
+            return await this.getTranscript(args as any);
+          default:
+            throw new Error(`Unknown tool: ${name}`);
+        }
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Error: ${error instanceof Error ? error.message : 'Unknown error'}`
+            }
+          ]
+        };
+      }
+    });
+  }
+
+  private getAxios() {
+    return axios.create({
+      baseURL: this.baseUrl,
+      headers: { Authorization: `Bearer ${this.apiToken}` }
+    });
+  }
+
+  private getTools(): Tool[] {
+    return [
+      {
+        name: 'upload_audio',
+        description: 'Upload an audio file for transcription',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            file: { type: 'string', description: 'Base64 encoded audio file' },
+            filename: { type: 'string', description: 'Filename for the upload' }
+          },
+          required: ['file', 'filename']
+        }
+      },
+      {
+        name: 'list_transcripts',
+        description: 'List available transcripts',
+        inputSchema: { type: 'object', properties: {} }
+      },
+      {
+        name: 'get_transcript',
+        description: 'Retrieve a specific transcript',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            id: { type: 'string', description: 'Transcript ID' }
+          },
+          required: ['id']
+        }
+      }
+    ];
+  }
+
+  private async uploadAudio(args: { file: string; filename: string }) {
+    const buffer = Buffer.from(args.file, 'base64');
+    const form = new FormData();
+    form.append('file', buffer, args.filename);
+
+    const axiosInstance = this.getAxios();
+    const response = await axiosInstance.post('/v1/import', form, {
+      headers: form.getHeaders()
+    });
+
+    return { content: [{ type: 'text', text: JSON.stringify(response.data, null, 2) }] };
+  }
+
+  private async listTranscripts() {
+    const axiosInstance = this.getAxios();
+    const response = await axiosInstance.get('/v1/transcripts');
+    return { content: [{ type: 'text', text: JSON.stringify(response.data, null, 2) }] };
+  }
+
+  private async getTranscript(args: { id: string }) {
+    const axiosInstance = this.getAxios();
+    const response = await axiosInstance.get(`/v1/transcripts/${args.id}`);
+    return { content: [{ type: 'text', text: JSON.stringify(response.data, null, 2) }] };
+  }
+
+  async run() {
+    const transport = new StdioServerTransport();
+    await this.server.connect(transport);
+    console.error('Otter.ai MCP server running on stdio');
+  }
+}
+
+const server = new OtterMCPServer();
+server.run().catch(console.error);
+

--- a/src/servers/perplexity.ts
+++ b/src/servers/perplexity.ts
@@ -538,3 +538,4 @@ class PerplexityMCPServer {
 
 const server = new PerplexityMCPServer();
 server.run().catch(console.error);
+

--- a/src/servers/puppeteer.ts
+++ b/src/servers/puppeteer.ts
@@ -1220,3 +1220,4 @@ class PuppeteerMCPServer {
 
 const server = new PuppeteerMCPServer();
 server.run().catch(console.error);
+

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -246,3 +246,12 @@ export interface ScrapingResult {
   images?: string[];
   metadata?: Record<string, any>;
 }
+// Otter.ai Types
+export interface OtterTranscript {
+  id: string;
+  title: string;
+  created_time: string;
+  status: 'processing' | 'completed' | 'failed';
+  url?: string;
+}
+

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -23,6 +23,7 @@ export interface Secrets {
   NOTION_INTEGRATION_SECRET?: string;
   OPENAI_API_KEY?: string;
   PERPLEXITY_API_KEY?: string;
+  OTTER_API_TOKEN?: string;
 }
 
 export function checkSecrets(): Secrets {
@@ -34,5 +35,7 @@ export function checkSecrets(): Secrets {
     NOTION_INTEGRATION_SECRET: process.env.NOTION_INTEGRATION_SECRET,
     OPENAI_API_KEY: process.env.OPENAI_API_KEY,
     PERPLEXITY_API_KEY: process.env.PERPLEXITY_API_KEY,
+    OTTER_API_TOKEN: process.env.OTTER_API_TOKEN,
   };
 }
+


### PR DESCRIPTION
## Summary
- add new Otter.ai MCP server with upload and transcript methods
- support OTTER_API_TOKEN in environment utilities and main server
- document Otter.ai integration in README
- expose new `otter` npm script
- ensure source files end with newlines

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68769ed219d88327aa2f4bc503e119a5